### PR TITLE
Feature/label tag retarget

### DIFF
--- a/src/NHSUKFrontEndLibraryTagHelpers/NHSUK.FrontEndLibrary.TagHelpers/Constants/TagHelperNames.cs
+++ b/src/NHSUKFrontEndLibraryTagHelpers/NHSUK.FrontEndLibrary.TagHelpers/Constants/TagHelperNames.cs
@@ -45,7 +45,6 @@
     public const string NhsContainerTag = "nhs-width-container";
     public const string NhsMainWrapperTag = "nhs-main-wrapper";
     public const string NhsGridRowTag = "nhs-grid-row";
-    public const string NhsLabelTag = "nhs-label";
     public const string NhsInputTag = "nhs-input";
     public const string NhsBackLinkTag = "nhs-back-link";
     public const string NhsErrorMessageTag = "nhs-error-message";

--- a/src/NHSUKFrontEndLibraryTagHelpers/NHSUK.FrontEndLibrary.TagHelpers/NHSUK.FrontEndLibrary.TagHelpers.csproj
+++ b/src/NHSUKFrontEndLibraryTagHelpers/NHSUK.FrontEndLibrary.TagHelpers/NHSUK.FrontEndLibrary.TagHelpers.csproj
@@ -9,7 +9,7 @@
     <Copyright>NHS Digital</Copyright>
     <PackageTags>nhs-uk nhs-digital nhsuk-frontend taghelpers</PackageTags>
     <PackageReleaseNotes>A cross-platform base package of Razor Tag Helper for Dotnet Core. To be used in conjunction with the NHS.UK Front End Library.</PackageReleaseNotes>
-    <Version>1.0.11-alpha</Version>
+    <Version>1.1.0-alpha</Version>
     <PackageId>NHSUK.FrontEndLibrary.TagHelpers</PackageId>
     <Product>NHSUK FrontEnd Library TagHelpers</Product>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/src/NHSUKFrontEndLibraryTagHelpers/NHSUK.FrontEndLibrary.TagHelpers/NHSUK.FrontEndLibrary.TagHelpers.csproj
+++ b/src/NHSUKFrontEndLibraryTagHelpers/NHSUK.FrontEndLibrary.TagHelpers/NHSUK.FrontEndLibrary.TagHelpers.csproj
@@ -9,7 +9,7 @@
     <Copyright>NHS Digital</Copyright>
     <PackageTags>nhs-uk nhs-digital nhsuk-frontend taghelpers</PackageTags>
     <PackageReleaseNotes>A cross-platform base package of Razor Tag Helper for Dotnet Core. To be used in conjunction with the NHS.UK Front End Library.</PackageReleaseNotes>
-    <Version>1.0.10-alpha</Version>
+    <Version>1.0.11-alpha</Version>
     <PackageId>NHSUK.FrontEndLibrary.TagHelpers</PackageId>
     <Product>NHSUK FrontEnd Library TagHelpers</Product>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/src/NHSUKFrontEndLibraryTagHelpers/NHSUK.FrontEndLibrary.TagHelpers/Tags/Checkboxes/README.md
+++ b/src/NHSUKFrontEndLibraryTagHelpers/NHSUK.FrontEndLibrary.TagHelpers/Tags/Checkboxes/README.md
@@ -55,15 +55,15 @@ Find out more about the checkboxes component and when to use it in the [NHS digi
     <nhs-checkboxes>
       <nhs-checkboxes-item>
         <nhs-input nhs-input-type="Checkboxes" id="nationality-1" name="nationality" value="british"></nhs-input>
-        <nhs-label nhs-label-type="Checkboxes" for="nationality-1">British</nhs-label>
+        <label nhs-label-type="Checkboxes" for="nationality-1">British</label>
       </nhs-checkboxes-item>
       <nhs-checkboxes-item>
         <nhs-input nhs-input-type="Checkboxes" id="nationality-2" name="nationality" value="irish"></nhs-input>
-        <nhs-label nhs-label-type="Checkboxes" for="nationality-2">Irish</nhs-label>
+        <label nhs-label-type="Checkboxes" for="nationality-2">Irish</label>
       </nhs-checkboxes-item>
       <nhs-checkboxes-item>
         <nhs-input nhs-input-type="Checkboxes" id="nationality-3" name="nationality" value="other"></nhs-input>
-        <nhs-label nhs-label-type="Checkboxes" for="nationality-3">citizen of another country</nhs-label>
+        <label nhs-label-type="Checkboxes" for="nationality-3">citizen of another country</label>
       </nhs-checkboxes-item>
     </nhs-checkboxes>
   </nhs-fieldset>
@@ -123,12 +123,12 @@ Find out more about the checkboxes component and when to use it in the [NHS digi
     <nhs-checkboxes>
       <nhs-checkboxes-item>
         <nhs-input nhs-input-type="Checkboxes" id="government-gateway" name="gateway" value="gov-gateway" aria-describedby="government-gateway-item-hint"></nhs-input>
-        <nhs-label nhs-label-type="Checkboxes" for="government-gateway">Sign in with Government Gateway</nhs-label>
+        <label nhs-label-type="Checkboxes" for="government-gateway">Sign in with Government Gateway</label>
         <nhs-hint nhs-hint-type="Checkboxes" id="government-gateway-item-hint">You’ll have a user ID if you’ve registered for Self Assessment or filed a tax return online before.</nhs-hint>
       </nhs-checkboxes-item>
       <nhs-checkboxes-item>
         <nhs-input nhs-input-type="Checkboxes" id="nhsuk-login" name="verify" value="nhsuk-verify" aria-describedby="nhsuk-login-item-hint"></nhs-input>
-        <nhs-label nhs-label-type="Checkboxes" for="nhsuk-login">Sign in with NHS.UK login</nhs-label>
+        <label nhs-label-type="Checkboxes" for="nhsuk-login">Sign in with NHS.UK login</label>
         <nhs-hint nhs-hint-type="Checkboxes" id="nhsuk-login-item-hint">You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.</nhs-hint>
       </nhs-checkboxes-item>
     </nhs-checkboxes>
@@ -176,15 +176,15 @@ Find out more about the checkboxes component and when to use it in the [NHS digi
   <nhs-checkboxes>
     <nhs-checkboxes-item>
       <nhs-input nhs-input-type="Checkboxes" id="colours-1" name="colours" value="red"></nhs-input>
-      <nhs-label nhs-label-type="Checkboxes" for="colours-1">Red</nhs-label>
+      <label nhs-label-type="Checkboxes" for="colours-1">Red</label>
     </nhs-checkboxes-item>
     <nhs-checkboxes-item>
       <nhs-input nhs-input-type="Checkboxes" id="colours-2" name="colours" value="green"></nhs-input>
-      <nhs-label nhs-label-type="Checkboxes" for="colours-2">Green</nhs-label>
+      <label nhs-label-type="Checkboxes" for="colours-2">Green</label>
     </nhs-checkboxes-item>
     <nhs-checkboxes-item>
       <nhs-input nhs-input-type="Checkboxes" id="colours-3" name="colours" value="blue" disabled></nhs-input>
-      <nhs-label nhs-label-type="Checkboxes" for="colours-3">Blue</nhs-label>
+      <label nhs-label-type="Checkboxes" for="colours-3">Blue</label>
     </nhs-checkboxes-item>
   </nhs-checkboxes>
 </nhs-form-group>
@@ -245,15 +245,15 @@ Find out more about the checkboxes component and when to use it in the [NHS digi
     <nhs-checkboxes>
       <nhs-checkboxes-item>
         <nhs-input nhs-input-type="Checkboxes" id="waste-1" name="waste" value="animal"></nhs-input>
-        <nhs-label nhs-label-type="Checkboxes" for="waste-1">Waste from animal carcasses</nhs-label>
+        <label nhs-label-type="Checkboxes" for="waste-1">Waste from animal carcasses</label>
       </nhs-checkboxes-item>
       <nhs-checkboxes-item>
         <nhs-input nhs-input-type="Checkboxes" id="waste-2" name="waste" value="mines"></nhs-input>
-        <nhs-label nhs-label-type="Checkboxes" for="waste-2">Waste from mines or quarries</nhs-label>
+        <label nhs-label-type="Checkboxes" for="waste-2">Waste from mines or quarries</label>
       </nhs-checkboxes-item>
       <nhs-checkboxes-item>
         <nhs-input nhs-input-type="Checkboxes" id="waste-3" name="waste" value="farm"></nhs-input>
-        <nhs-label nhs-label-type="Checkboxes" for="waste-3">Farm or agricultural waste</nhs-label>
+        <label nhs-label-type="Checkboxes" for="waste-3">Farm or agricultural waste</label>
       </nhs-checkboxes-item>
     </nhs-checkboxes>
   </nhs-fieldset>
@@ -311,15 +311,15 @@ Find out more about the checkboxes component and when to use it in the [NHS digi
     <nhs-checkboxes>
       <nhs-checkboxes-item>
         <nhs-input nhs-input-type="Checkboxes" id="waste-1" name="waste" value="animal"></nhs-input>
-        <nhs-label nhs-label-type="Checkboxes" for="waste-1">Waste from animal carcasses</nhs-label>
+        <label nhs-label-type="Checkboxes" for="waste-1">Waste from animal carcasses</label>
       </nhs-checkboxes-item>
       <nhs-checkboxes-item>
         <nhs-input nhs-input-type="Checkboxes" id="waste-2" name="waste" value="mines"></nhs-input>
-        <nhs-label nhs-label-type="Checkboxes" for="waste-2">Waste from mines or quarries</nhs-label>
+        <label nhs-label-type="Checkboxes" for="waste-2">Waste from mines or quarries</label>
       </nhs-checkboxes-item>
       <nhs-checkboxes-item>
         <nhs-input nhs-input-type="Checkboxes" id="waste-3" name="waste" value="farm"></nhs-input>
-        <nhs-label nhs-label-type="Checkboxes" for="waste-3">Farm or agricultural waste</nhs-label>
+        <label nhs-label-type="Checkboxes" for="waste-3">Farm or agricultural waste</label>
       </nhs-checkboxes-item>
     </nhs-checkboxes>
   </nhs-fieldset>

--- a/src/NHSUKFrontEndLibraryTagHelpers/NHSUK.FrontEndLibrary.TagHelpers/Tags/DateInput/README.md
+++ b/src/NHSUKFrontEndLibraryTagHelpers/NHSUK.FrontEndLibrary.TagHelpers/Tags/DateInput/README.md
@@ -65,19 +65,19 @@ Note: The `pattern` attribute is not valid HTML for inputs where the type attrib
     <nhs-date-input id="dob">
       <nhs-date-input-item>
         <nhs-form-group nhs-form-group-type="Standard">
-          <nhs-label nhs-label-type="Date" for="dob-day">Day</nhs-label>
+          <label nhs-label-type="Date" for="dob-day">Day</label>
           <nhs-input nhs-input-type="Date" fixed-width="Two" id="dob-day" name="dob-day"></nhs-input>
         </nhs-form-group>
       </nhs-date-input-item>
       <nhs-date-input-item>
         <nhs-form-group nhs-form-group-type="Standard">
-          <nhs-label nhs-label-type="Date" for="dob-month">Month</nhs-label>
+          <label nhs-label-type="Date" for="dob-month">Month</label>
           <nhs-input nhs-input-type="Date" fixed-width="Two" id="dob-month" name="dob-month"></nhs-input>
         </nhs-form-group>
       </nhs-date-input-item>
       <nhs-date-input-item>
         <nhs-form-group nhs-form-group-type="Standard">
-          <nhs-label nhs-label-type="Date" for="dob-year">Year</nhs-label>
+          <label nhs-label-type="Date" for="dob-year">Year</label>
           <nhs-input nhs-input-type="Date" fixed-width="Four" id="dob-year" name="dob-year"></nhs-input>
         </nhs-form-group>
       </nhs-date-input-item>
@@ -150,19 +150,19 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
     <nhs-date-input id="dob-with-autocomplete-attribute">
       <nhs-date-input-item>
         <nhs-form-group nhs-form-group-type="Standard">
-          <nhs-label nhs-label-type="Date" for="dob-with-autocomplete-attribute-day">Day</nhs-label>
+          <label nhs-label-type="Date" for="dob-with-autocomplete-attribute-day">Day</label>
           <nhs-input nhs-input-type="Date" fixed-width="Two" id="dob-with-autocomplete-attribute-day" name="dob-with-autocomplete-day" autocomplete="bday-day"></nhs-input>
         </nhs-form-group>
       </nhs-date-input-item>
       <nhs-date-input-item>
         <nhs-form-group nhs-form-group-type="Standard">
-          <nhs-label nhs-label-type="Date" for="dob-with-autocomplete-attribute-month">Month</nhs-label>
+          <label nhs-label-type="Date" for="dob-with-autocomplete-attribute-month">Month</label>
           <nhs-input nhs-input-type="Date" fixed-width="Two" id="dob-month" name="dob-with-autocomplete-month" autocomplete="bday-month"></nhs-input>
         </nhs-form-group>
       </nhs-date-input-item>
       <nhs-date-input-item>
         <nhs-form-group nhs-form-group-type="Standard">
-          <nhs-label nhs-label-type="Date" for="dob-with-autocomplete-attribute-year">Year</nhs-label>
+          <label nhs-label-type="Date" for="dob-with-autocomplete-attribute-year">Year</label>
           <nhs-input nhs-input-type="Date" fixed-width="Four" id="dob-year" name="dob-with-autocomplete-year" autocomplete="bday-year"></nhs-input>
         </nhs-form-group>
       </nhs-date-input-item>
@@ -234,19 +234,19 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
     <nhs-date-input id="dob-errors">
       <nhs-date-input-item>
         <nhs-form-group nhs-form-group-type="Standard">
-          <nhs-label nhs-label-type="Date" for="dob-errors-day">Day</nhs-label>
+          <label nhs-label-type="Date" for="dob-errors-day">Day</label>
           <nhs-input nhs-input-type="Date" fixed-width="Two" is-error-input="true" id="dob-errors-day" name="day"></nhs-input>
         </nhs-form-group>
       </nhs-date-input-item>
       <nhs-date-input-item>
         <nhs-form-group nhs-form-group-type="Standard">
-          <nhs-label nhs-label-type="Date" for="dob-errors-month">Month</nhs-label>
+          <label nhs-label-type="Date" for="dob-errors-month">Month</label>
           <nhs-input nhs-input-type="Date" fixed-width="Two" is-error-input="true" id="dob-errors-month" name="month"></nhs-input>
         </nhs-form-group>
       </nhs-date-input-item>
       <nhs-date-input-item>
         <nhs-form-group nhs-form-group-type="Standard">
-          <nhs-label nhs-label-type="Date" for="dob-errors-year">Year</nhs-label>
+          <label nhs-label-type="Date" for="dob-errors-year">Year</label>
           <nhs-input nhs-input-type="Date" fixed-width="Four" is-error-input="true" id="dob-errors-year" name="year"></nhs-input>
         </nhs-form-group>
       </nhs-date-input-item>
@@ -319,19 +319,19 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
     <nhs-date-input id="dob-day-error">
       <nhs-date-input-item>
         <nhs-form-group nhs-form-group-type="Standard">
-          <nhs-label nhs-label-type="Date" for="dob-day-error-day">Day</nhs-label>
+          <label nhs-label-type="Date" for="dob-day-error-day">Day</label>
           <nhs-input nhs-input-type="Date" fixed-width="Two" is-error-input="true" id="dob-day-error-day" name="dob-day-error-day"></nhs-input>
         </nhs-form-group>
       </nhs-date-input-item>
       <nhs-date-input-item>
         <nhs-form-group nhs-form-group-type="Standard">
-          <nhs-label nhs-label-type="Date" for="dob-errors-month">Month</nhs-label>
+          <label nhs-label-type="Date" for="dob-errors-month">Month</label>
           <nhs-input nhs-input-type="Date" fixed-width="Two" id="dob-day-error-month" name="dob-day-error-month"></nhs-input>
         </nhs-form-group>
       </nhs-date-input-item>
       <nhs-date-input-item>
         <nhs-form-group nhs-form-group-type="Standard">
-          <nhs-label nhs-label-type="Date" for="dob-errors-year">Year</nhs-label>
+          <label nhs-label-type="Date" for="dob-errors-year">Year</label>
           <nhs-input nhs-input-type="Date" fixed-width="Four" id="dob-day-error-year" name="dob-day-error-year"></nhs-input>
         </nhs-form-group>
       </nhs-date-input-item>

--- a/src/NHSUKFrontEndLibraryTagHelpers/NHSUK.FrontEndLibrary.TagHelpers/Tags/Fieldset/README.md
+++ b/src/NHSUKFrontEndLibraryTagHelpers/NHSUK.FrontEndLibrary.TagHelpers/Tags/Fieldset/README.md
@@ -108,19 +108,19 @@ Find out more about the fieldset component and when to use it in the [NHS digita
     What is your address?
   </nhs-fieldset-legend>
   <nhs-form-group nhs-form-group-type="Standard">
-    <nhs-label nhs-label-type="Standard" for="input-address1">Address line 1</nhs-label>
+    <label nhs-label-type="Standard" for="input-address1">Address line 1</label>
     <nhs-input nhs-input-type="Standard" id="input-address1" name="address1" type="text"></nhs-input>
   </nhs-form-group>
   <nhs-form-group nhs-form-group-type="Standard">
-    <nhs-label nhs-label-type="Standard" for="input-address2">Address line 2</nhs-label>
+    <label nhs-label-type="Standard" for="input-address2">Address line 2</label>
     <nhs-input nhs-input-type="Standard" id="input-address2" name="address2" type="text"></nhs-input>
   </nhs-form-group>
   <nhs-form-group nhs-form-group-type="Standard">
-    <nhs-label nhs-label-type="Standard" for="input-town-city">Town or city</nhs-label>
+    <label nhs-label-type="Standard" for="input-town-city">Town or city</label>
     <nhs-input nhs-input-type="Standard" id="input-town-city" name="town" type="text"></nhs-input>
   </nhs-form-group>
   <nhs-form-group nhs-form-group-type="Standard">
-    <nhs-label nhs-label-type="Standard" for="input-county">County</nhs-label>
+    <label nhs-label-type="Standard" for="input-county">County</label>
     <nhs-input nhs-input-type="Standard" id="input-county" name="county" type="text"></nhs-input>
   </nhs-form-group>
 </nhs-fieldset>

--- a/src/NHSUKFrontEndLibraryTagHelpers/NHSUK.FrontEndLibrary.TagHelpers/Tags/FormGroup/README.md
+++ b/src/NHSUKFrontEndLibraryTagHelpers/NHSUK.FrontEndLibrary.TagHelpers/Tags/FormGroup/README.md
@@ -15,7 +15,7 @@
 
 ```
 <nhs-form-group nhs-form-group-type="Standard">
-  <nhs-label nhs-label-type="Standard" for="input-example">National insurance number</nhs-label>
+  <label nhs-label-type="Standard" for="input-example">National insurance number</label>
   <nhs-input nhs-input-type="Standard" id="input-example" name="test-name"></nhs-input>
 </nhs-form-group>
 ```

--- a/src/NHSUKFrontEndLibraryTagHelpers/NHSUK.FrontEndLibrary.TagHelpers/Tags/Input/README.md
+++ b/src/NHSUKFrontEndLibraryTagHelpers/NHSUK.FrontEndLibrary.TagHelpers/Tags/Input/README.md
@@ -25,7 +25,7 @@ Find out more about the input component and when to use it in the [NHS digital s
 
 ```
 <nhs-form-group nhs-form-group-type="Standard">
-  <nhs-label nhs-label-type="Standard" for="input-example">National insurance number</nhs-label>
+  <label nhs-label-type="Standard" for="input-example">National insurance number</label>
   <nhs-input nhs-input-type="Standard" id="input-example" name="test-name"></nhs-input>
 </nhs-form-group>
 ```
@@ -52,7 +52,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
 #### Taghelper markup
 ```
 <nhs-form-group nhs-form-group-type="Standard">
-  <nhs-label nhs-label-type="Standard" for="input-with-autocomplete-attribute">Postcode</nhs-label>
+  <label nhs-label-type="Standard" for="input-with-autocomplete-attribute">Postcode</label>
   <nhs-input nhs-input-type="Standard" id="input-with-autocomplete-attribute" name="postcode" autocomplete="postal-code"></nhs-input>
 </nhs-form-group>
 ```
@@ -80,7 +80,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
 
 ```
 <nhs-form-group nhs-form-group-type="Standard">
-  <nhs-label nhs-label-type="Standard" for="input-with-hint-text">National insurance number</nhs-label>
+  <label nhs-label-type="Standard" for="input-with-hint-text">National insurance number</label>
   <nhs-hint nhs-hint-type="Standard" id="input-with-hint-text-hint">It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.</nhs-hint>
   <nhs-input nhs-input-type="Standard" id="input-with-hint-text" name="test-name-2" aria-describedby="input-with-hint-text-hint"></nhs-input>
 </nhs-form-group>
@@ -112,7 +112,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
 
 ```
 <nhs-form-group nhs-form-group-type="Error">
-  <nhs-label nhs-label-type="Standard" for="input-with-error-message">National insurance number</nhs-label>
+  <label nhs-label-type="Standard" for="input-with-error-message">National insurance number</label>
   <nhs-hint nhs-hint-type="Standard" id="input-with-error-message-hint">It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.</nhs-hint>
   <nhs-error-message id="input-with-error-message-error">Error message goes here</nhs-error-message>
   <nhs-input nhs-input-type="Standard" is-error-input="true" id="input-with-error-message" name="test-name-3" aria-describedby="input-with-error-message-hint input-with-error-message-error"></nhs-input>
@@ -142,7 +142,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
 
 ```
 <nhs-form-group nhs-form-group-type="Standard">
-  <nhs-label nhs-label-type="Standard" for="input-width-10">National insurance number</nhs-label>
+  <label nhs-label-type="Standard" for="input-width-10">National insurance number</label>
   <nhs-hint nhs-hint-type="Standard" id="input-width-10-hint">It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.</nhs-hint>
   <nhs-input nhs-input-type="Standard" fixed-width="Ten" id="input-width-10" name="test-width-10" aria-describedby="input-width-10-hint"></nhs-input>
 </nhs-form-group>

--- a/src/NHSUKFrontEndLibraryTagHelpers/NHSUK.FrontEndLibrary.TagHelpers/Tags/Label/NhsLabelTagHelper.cs
+++ b/src/NHSUKFrontEndLibraryTagHelpers/NHSUK.FrontEndLibrary.TagHelpers/Tags/Label/NhsLabelTagHelper.cs
@@ -4,7 +4,7 @@ using NHSUK.FrontEndLibrary.TagHelpers.Constants;
 
 namespace NHSUK.FrontEndLibrary.TagHelpers.Tags.Label
 {
-  [HtmlTargetElement(TagHelperNames.NhsLabelTag,
+  [HtmlTargetElement("label",
     Attributes = NhsUkTagHelperAttributes.LabelType)]
   public class NhsLabelTagHelper : NhsBaseTagHelper
   {
@@ -52,8 +52,8 @@ namespace NHSUK.FrontEndLibrary.TagHelpers.Tags.Label
           break;
       }
 
-      var content = (await output.GetChildContentAsync()).GetContent();
-      output.Content.SetHtmlContent(content);
+      //var content = (await output.GetChildContentAsync()).GetContent();
+      //output.Content.SetHtmlContent(content);
       UpdateClasses(output);
     }
   }

--- a/src/NHSUKFrontEndLibraryTagHelpers/NHSUK.FrontEndLibrary.TagHelpers/Tags/Label/README.md
+++ b/src/NHSUKFrontEndLibraryTagHelpers/NHSUK.FrontEndLibrary.TagHelpers/Tags/Label/README.md
@@ -17,7 +17,7 @@
 #### Taghelper markup
 
 ```
-<nhs-label nhs-label-type="Standard">National Insurance number</nhs-label>
+<label nhs-label-type="Standard">National Insurance number</label>
 
 ```
 
@@ -38,7 +38,7 @@
 #### Taghelper markup
 
 ```
-<nhs-label nhs-label-type="Bold">National Insurance number</nhs-label>
+<label nhs-label-type="Bold">National Insurance number</label>
 
 ```
 
@@ -61,7 +61,7 @@
 #### Taghelper markup
 
 ```
-<nhs-label nhs-label-type="PageHeading">National Insurance number</nhs-label>
+<label nhs-label-type="PageHeading">National Insurance number</label>
 ```
 
 ---

--- a/src/NHSUKFrontEndLibraryTagHelpers/NHSUK.FrontEndLibrary.TagHelpers/Tags/Radios/README.md
+++ b/src/NHSUKFrontEndLibraryTagHelpers/NHSUK.FrontEndLibrary.TagHelpers/Tags/Radios/README.md
@@ -49,11 +49,11 @@ Find out more about the radios component and when to use it in the [NHS digital 
     <nhs-radios nhs-radios-type="Standard">
       <nhs-radios-item>
         <nhs-input nhs-input-type="Radios" id="example-1" name="example" value="yes"></nhs-input>
-        <nhs-label nhs-label-type="Radios" for="example-1">Yes</nhs-label>
+        <label nhs-label-type="Radios" for="example-1">Yes</label>
       </nhs-radios-item>
       <nhs-radios-item>
         <nhs-input nhs-input-type="Radios" id="example-2" name="example" value="no" checked></nhs-input>
-        <nhs-label nhs-label-type="Radios" for="example-2">No</nhs-label>
+        <label nhs-label-type="Radios" for="example-2">No</label>
       </nhs-radios-item>
     </nhs-radios>
   </nhs-fieldset>
@@ -105,11 +105,11 @@ Find out more about the radios component and when to use it in the [NHS digital 
     <nhs-radios nhs-radios-type="Inline">
       <nhs-radios-item>
         <nhs-input nhs-input-type="Radios" id="example-1" name="example" value="yes"></nhs-input>
-        <nhs-label nhs-label-type="Radios" for="example-1">Yes</nhs-label>
+        <label nhs-label-type="Radios" for="example-1">Yes</label>
       </nhs-radios-item>
       <nhs-radios-item>
         <nhs-input nhs-input-type="Radios" id="example-2" name="example" value="no" checked></nhs-input>
-        <nhs-label nhs-label-type="Radios" for="example-2">No</nhs-label>
+        <label nhs-label-type="Radios" for="example-2">No</label>
       </nhs-radios-item>
     </nhs-radios>
   </nhs-fieldset>
@@ -161,11 +161,11 @@ Find out more about the radios component and when to use it in the [NHS digital 
     <nhs-radios nhs-radios-type="Standard">
       <nhs-radios-item>
         <nhs-input nhs-input-type="Radios" id="example-disabled-1" name="example-disabled" value="yes" disabled></nhs-input>
-        <nhs-label nhs-label-type="Radios" for="example-disabled-1">Yes</nhs-label>
+        <label nhs-label-type="Radios" for="example-disabled-1">Yes</label>
       </nhs-radios-item>
       <nhs-radios-item>
         <nhs-input nhs-input-type="Radios" id="example-disabled-2" name="example-disabled" value="no" disabled></nhs-input>
-        <nhs-label nhs-label-type="Radios" for="example-disabled-2">No</nhs-label>
+        <label nhs-label-type="Radios" for="example-disabled-2">No</label>
       </nhs-radios-item>
     </nhs-radios>
   </nhs-fieldset>
@@ -220,16 +220,16 @@ Find out more about the radios component and when to use it in the [NHS digital 
     <nhs-radios nhs-radios-type="Standard">
       <nhs-radios-item>
         <nhs-input nhs-input-type="Radios" id="example-divider-1" name="example" value="government-gateway"></nhs-input>
-        <nhs-label nhs-label-type="Radios" for="example-divider-1">Use Government Gateway</nhs-label>
+        <label nhs-label-type="Radios" for="example-divider-1">Use Government Gateway</label>
       </nhs-radios-item>
       <nhs-radios-item>
         <nhs-input nhs-input-type="Radios" id="example-divider-2" name="example" value="nhsuk-login"></nhs-input>
-        <nhs-label nhs-label-type="Radios" for="example-divider-2">Use NHS.UK login</nhs-label>
+        <label nhs-label-type="Radios" for="example-divider-2">Use NHS.UK login</label>
       </nhs-radios-item>
       <nhs-radios-divider>or</nhs-radios-divider>
       <nhs-radios-item>
         <nhs-input nhs-input-type="Radios" id="example-divider-4" name="example" value="create-account"></nhs-input>
-        <nhs-label nhs-label-type="Radios" for="example-divider-4">Create an account</nhs-label>
+        <label nhs-label-type="Radios" for="example-divider-4">Create an account</label>
       </nhs-radios-item>
     </nhs-radios>
   </nhs-fieldset>
@@ -287,14 +287,14 @@ Find out more about the radios component and when to use it in the [NHS digital 
     <nhs-radios nhs-radios-type="Standard">
       <nhs-radios-item>
         <nhs-input nhs-input-type="Radios" id="gov-1" name="gov" value="gateway" aria-describedby="gov-1-item-hint"></nhs-input>
-        <nhs-label nhs-label-type="Radios" for="gov-1">Sign in with Government Gateway</nhs-label>
+        <label nhs-label-type="Radios" for="gov-1">Sign in with Government Gateway</label>
         <nhs-hint nhs-hint-type="Radios" id="gov-1-item-hint">
           You'll have a user ID if you've registered for self-assessment or filed a tax return online before.
         </nhs-hint>
       </nhs-radios-item>
       <nhs-radios-item>
         <nhs-input nhs-input-type="Radios" id="gov-2" name="gov" value="verify" aria-describedby="gov-2-item-hint"></nhs-input>
-        <nhs-label nhs-label-type="Radios" for="gov-2">Sign in with NHS.UK login</nhs-label>
+        <label nhs-label-type="Radios" for="gov-2">Sign in with NHS.UK login</label>
         <nhs-hint nhs-hint-type="Radios" id="gov-2-item-hint">
           You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
         </nhs-hint>
@@ -344,15 +344,15 @@ Find out more about the radios component and when to use it in the [NHS digital 
   <nhs-radios nhs-radios-type="Standard">
     <nhs-radios-item>
       <nhs-input nhs-input-type="Radios" id="colours-1" name="colours" value="red"></nhs-input>
-      <nhs-label nhs-label-type="Radios" for="colours-1">Red</nhs-label>
+      <label nhs-label-type="Radios" for="colours-1">Red</label>
     </nhs-radios-item>
     <nhs-radios-item>
       <nhs-input nhs-input-type="Radios" id="colours-2" name="colours" value="green"></nhs-input>
-      <nhs-label nhs-label-type="Radios" for="colours-2">Green</nhs-label>
+      <label nhs-label-type="Radios" for="colours-2">Green</label>
     </nhs-radios-item>
     <nhs-radios-item>
       <nhs-input nhs-input-type="Radios" id="colours-3" name="colours" value="blue"></nhs-input>
-      <nhs-label nhs-label-type="Radios" for="colours-3">Blue</nhs-label>
+      <label nhs-label-type="Radios" for="colours-3">Blue</label>
     </nhs-radios-item>
   </nhs-radios>
 </nhs-form-group>
@@ -406,11 +406,11 @@ Find out more about the radios component and when to use it in the [NHS digital 
     <nhs-radios nhs-radios-type="Standard">
       <nhs-radios-item>
         <nhs-input nhs-input-type="Radios" id="example-1" name="example" value="yes"></nhs-input>
-        <nhs-label nhs-label-type="Radios" for="example-1">Yes</nhs-label>
+        <label nhs-label-type="Radios" for="example-1">Yes</label>
       </nhs-radios-item>
       <nhs-radios-item>
         <nhs-input nhs-input-type="Radios" id="example-2" name="example" value="no" checked></nhs-input>
-        <nhs-label nhs-label-type="Radios" for="example-2">No</nhs-label>
+        <label nhs-label-type="Radios" for="example-2">No</label>
       </nhs-radios-item>
     </nhs-radios>
   </nhs-fieldset>

--- a/src/NHSUKFrontEndLibraryTagHelpers/NHSUK.FrontEndLibrary.TagHelpers/Tags/Select/README.md
+++ b/src/NHSUKFrontEndLibraryTagHelpers/NHSUK.FrontEndLibrary.TagHelpers/Tags/Select/README.md
@@ -29,7 +29,7 @@ Find out more about the select component and when to use it in the [NHS digital 
 
 ```
 <nhs-form-group nhs-form-group-type="Standard">
-  <nhs-label nhs-label-type="Standard" for="select-1">Label text goes here</nhs-label>
+  <label nhs-label-type="Standard" for="select-1">Label text goes here</label>
   <nhs-select nhs-select-type="Standard" id="select-1" name="select-1">
     <option value="1">NHS.UK frontend option 1</option>
     <option value="2" selected>NHS.UK frontend option 2</option>
@@ -69,7 +69,7 @@ Find out more about the select component and when to use it in the [NHS digital 
 
 ```
 <nhs-form-group nhs-form-group-type="Error">
-  <nhs-label nhs-label-type="Standard" for="select-2">Label text goes here</nhs-label>
+  <label nhs-label-type="Standard" for="select-2">Label text goes here</label>
   <nhs-hint nhs-hint-type="Standard" id="select-2-hint">Hint text goes here</nhs-hint>
   <nhs-error-message id="select-2-error">Error message goes here</nhs-error-message>
   <nhs-select nhs-select-type="Error" id="select-2" name="select-2" aria-describedby="select-2-hint select-2-error">

--- a/src/NHSUKFrontEndLibraryTagHelpers/NHSUK.FrontEndLibrary.TagHelpers/Tags/TextArea/README.md
+++ b/src/NHSUKFrontEndLibraryTagHelpers/NHSUK.FrontEndLibrary.TagHelpers/Tags/TextArea/README.md
@@ -28,7 +28,7 @@ Find out more about the textarea component and when to use it in the [NHS digita
 
 ```
 <nhs-form-group nhs-form-group-type="Standard">
-  <nhs-label nhs-label-type="Standard" for="more-detail">Can you provide more detail?</nhs-label>
+  <label nhs-label-type="Standard" for="more-detail">Can you provide more detail?</label>
   <nhs-hint nhs-hint-type="Standard" id="more-detail-hint">Don't include personal or financial information, eg your National Insurance number or credit card details.</nhs-hint>
   <nhs-text-area nhs-textarea-type="Standard" id="more-detail" name="more-detail" rows="5" aria-describedby="more-detail-hint"></nhs-text-area>
 </nhs-form-group>
@@ -59,7 +59,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
 
 ```
 <nhs-form-group nhs-form-group-type="Standard">
-  <nhs-label nhs-label-type="Standard" for="textarea-with-autocomplete-attribute">Full address</nhs-label>
+  <label nhs-label-type="Standard" for="textarea-with-autocomplete-attribute">Full address</label>
   <nhs-text-area nhs-textarea-type="Standard" id="textarea-with-autocomplete-attribute" name="address" rows="5" autocomplete="street-address"></nhs-text-area>
 </nhs-form-group>
 ```
@@ -87,7 +87,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
 
 ```
 <nhs-form-group nhs-form-group-type="Error">
-  <nhs-label nhs-label-type="Standard" for="no-ni-reason">Why can't you provide a National Insurance number?</nhs-label>
+  <label nhs-label-type="Standard" for="no-ni-reason">Why can't you provide a National Insurance number?</label>
   <nhs-error-message id="no-ni-reason-error"> You must provide an explanation</nhs-error-message>
   <nhs-text-area nhs-textarea-type="Error" id="no-ni-reason" name="no-ni-reason" rows="5" aria-describedby="no-ni-reason-error"></nhs-text-area>
 </nhs-form-group>

--- a/tests/NHSUK.FrontEndLibrary.TagHelpers.Tests.Unit/NhsLabelTagHelperTests.cs
+++ b/tests/NHSUK.FrontEndLibrary.TagHelpers.Tests.Unit/NhsLabelTagHelperTests.cs
@@ -32,13 +32,6 @@ namespace NHSUK.FrontEndLibrary.TagHelpers.Tests.Unit
     }
 
     [Fact]
-    public async void ProcessAsync_Should_Set_Content()
-    {
-      await _tagHelper.ProcessAsync(_tagHelperContext, _tagHelperOutput);
-      Assert.Equal(Text, _tagHelperOutput.Content.GetContent());
-    }
-
-    [Fact]
     public async void ProcessAsync_Should_Set_TagName()
     {
       await _tagHelper.ProcessAsync(_tagHelperContext, _tagHelperOutput);


### PR DESCRIPTION
This re-targets the label tag helper at the label HTML element directly. No need for a 'nhs-' type tag.

Updated all readme documentation and example usage.

This approach works with the out of the box 'asp-for' construct.

